### PR TITLE
Update index.html.de

### DIFF
--- a/source/index.html.de
+++ b/source/index.html.de
@@ -318,7 +318,7 @@
 	  </a>
       </div>
       <div class="col-md-3 col-sm-6">
-	  <a href="https://stackhpc.com">
+	  <a href="https://www.stackhpc.com">
           <img src="images/logo-stackhpc.png" class="logo-stackhpc" alt="StackHPC Logo" title="STackHPC" />
 	  </a>
       </div>

--- a/source/index.html.en
+++ b/source/index.html.en
@@ -321,7 +321,7 @@
           </a>
       </div>
       <div class="col-md-3 col-sm-6">
-          <a href="https://stackhpc.com">
+          <a href="https://www.stackhpc.com">
           <img src="images/logo-stackhpc.png" class="logo-stackhpc" alt="StackHPC Logo" title="STackHPC" />
           </a>
       </div>


### PR DESCRIPTION
At the moment the link to https://stackhpc.com results in an error because their certificate is only valid for www.stackhpc.com and looks like there is no redirect from https://stackhpc.com to https://www.stackhpc.com in place.

This patch will fix this behaviour by using https://www.stackhpc.com as link instead of https://stackhpc.com